### PR TITLE
This is a usage fix.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 coverage
+node_modules

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "package.json",
     "README.md",
     "LICENSE",
-    "index.js"
+    "index.js",
+    "lib"
   ],
   "bugs": {
     "url": "https://github.com/lance/opossum/issues"


### PR DESCRIPTION
When using opossum via 'file:../opossum'
and after npm install, we have no 'lib' directory
causing the error :

```
Error: Cannot find module './lib/circuit'
    at Function.Module._resolveFilename (module.js:325:15)
    at Function.Module._load (module.js:276:25)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous>
(/mnt/datadisk/roi/node_modules/opossum/index.js:3:24)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
```