### PR TITLE
remove PENDING_CLOSE flag

### DIFF
--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -7,7 +7,6 @@ const STATE = Symbol('state');
 const OPEN = Symbol('open');
 const CLOSED = Symbol('closed');
 const HALF_OPEN = Symbol('half-open');
-const PENDING_CLOSE = Symbol('pending-close');
 const FALLBACK_FUNCTION = Symbol('fallback');
 const NUM_FAILURES = Symbol('num-failures');
 const STATUS = Symbol('status');
@@ -46,7 +45,6 @@ class CircuitBreaker extends EventEmitter {
     this[STATUS] = new Status(this);
     this[STATE] = CLOSED;
     this[FALLBACK_FUNCTION] = null;
-    this[PENDING_CLOSE] = false;
     this[NUM_FAILURES] = 0;
 
     function _startTimer (circuit) {
@@ -139,12 +137,11 @@ class CircuitBreaker extends EventEmitter {
     this.emit('fire');
     const args = Array.prototype.slice.call(arguments);
 
-    if (this.opened || (this.halfOpen && this[PENDING_CLOSE])) {
+    if (this.opened) {
       this.emit('reject');
       return failFast(this, 'Breaker is open', args);
     }
 
-    this[PENDING_CLOSE] = this.halfOpen;
     return new this.Promise((resolve, reject) => {
       const timeout = setTimeout(
         () => {


### PR DESCRIPTION
We have come across a problem when try to use this module. We found that the circuit breaker will be kept open if it's going to the "halfOpen" state the second time. There will be no way to close the circuit breaker afterwards.

After a little of debugging, it looks like the problem is caused by the `PENDING_CLOSE` flag. I can't really tell why we need the flag, and removing it fix the problem. 

The case is being shown in the test.

@lance can you please review this and see if I am right? 

Thanks.