### PR TITLE
Addition of streaming hystrix data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,3 +231,11 @@ you create the breaker. E.g.
 // Force opossum to use native JS promises
 const breaker = circuitBreaker(readFile, { Promise: Promise });
 ```
+
+### Hystrix Metrics
+
+A Hystrix Stream is available for use with a Hystrix Dashboard using the `circuitBreaker.hystrixStats.getHystrixStream` method.
+
+This method returns a [Node.js Stream](https://nodejs.org/api/stream.html), which makes it easy to create an SSE stream that will be compliant with a Hystrix Dashboard.
+
+Additional Reading: [Hystrix Metrics Event Stream](https://github.com/Netflix/Hystrix/tree/master/hystrix-contrib/hystrix-metrics-event-stream), [Turbine](https://github.com/Netflix/Turbine/wiki), [Hystrix Dashboard](https://github.com/Netflix/Hystrix/wiki/Dashboard)

--- a/examples/hystrix/README.md
+++ b/examples/hystrix/README.md
@@ -1,0 +1,24 @@
+# Hystrix Example
+
+This example shows how to access the Hystrix Metrics and create an SSE stream that can be plugged into the Hystrix Dashboard.
+
+Similiar to the jQuery example, a simple service is exposed at the route `http://localhost:3000`. As the service receives requests, it gets slower and slower. Once it takes more than 1 second to respond, the service just returns a `423 (Locked)` error.  There is also a SSE stream available at `http://localhost:3000/hystrix.stream`
+
+To see the Hystrix Metrics in action, you will need to run the Hystrix Dashboard.  There are instructions on how to do that here: https://github.com/Netflix/Hystrix/tree/master/hystrix-dashboard
+
+Once the dashboard is running, navigate to `http://localhost:7979/hystrix-dashboard` (this assumes you are running it from the git repo), and add our servers hystrix stream.
+
+Now make a few requests to `http://localhost:3000` and you should see movement on the dashboard
+
+
+Install the dependecies
+
+```sh
+$ npm install
+```
+
+Start the server.
+
+```sh
+$ npm start
+```

--- a/examples/hystrix/app.js
+++ b/examples/hystrix/app.js
@@ -1,0 +1,70 @@
+const express = require('express');
+const bodyParser = require('body-parser');
+
+const app = express();
+
+const circuitBreaker = require('../../');
+
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({ extended: false }));
+
+const baseline = process.env.CB_BASELINE || 20;
+let delay = baseline;
+
+function flakeFunction () {
+  return new Promise((resolve, reject) => {
+    if (delay > 1000) {
+      return reject('Flakey Service is Flakey');
+    }
+
+    setTimeout(() => {
+      console.log('replying with flakey response after delay of ', delay);
+      resolve(`Sending flakey service. Current Delay at ${delay}`);
+      delay = delay * 2;
+    }, delay);
+  });
+}
+
+setInterval(() => {
+  if (delay !== baseline) {
+    delay = baseline;
+    console.log('resetting flakey service delay', delay);
+  }
+}, 20000);
+
+// circuit breaker
+const circuitBreakerOptions = {
+  maxFailures: 5,
+  timeout: 5000,
+  resetTimeout: 10000,
+  name: 'customName',
+  group: 'customGroupName'
+};
+
+function fallback () {
+  return 'Service Fallback';
+}
+
+const circuit = circuitBreaker(flakeFunction, circuitBreakerOptions);
+circuit.fallback(fallback);
+
+const hystrixStats = circuit.hystrixStats;
+
+// setup our SSE endpoint
+app.use('/hystrix.stream', (request, response) => {
+  response.writeHead(200, {'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache', 'Connection': 'keep-alive'});
+  response.write('retry: 10000\n');
+  response.write('event: connecttime\n');
+
+  hystrixStats.getHystrixStream().pipe(response);
+});
+
+app.use('/', (request, response) => {
+  circuit.fire().then((result) => {
+    response.send(result);
+  }).catch((err) => {
+    response.send(err);
+  });
+});
+
+module.exports = app;

--- a/examples/hystrix/bin/www
+++ b/examples/hystrix/bin/www
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+/**
+ * Module dependencies.
+ */
+
+var app = require('../app');
+var debug = require('debug')('hystrix:server');
+var http = require('http');
+
+/**
+ * Get port from environment and store in Express.
+ */
+
+var port = normalizePort(process.env.PORT || '3000');
+app.set('port', port);
+
+/**
+ * Create HTTP server.
+ */
+
+var server = http.createServer(app);
+
+/**
+ * Listen on provided port, on all network interfaces.
+ */
+
+server.listen(port);
+server.on('error', onError);
+server.on('listening', onListening);
+
+/**
+ * Normalize a port into a number, string, or false.
+ */
+
+function normalizePort(val) {
+  var port = parseInt(val, 10);
+
+  if (isNaN(port)) {
+    // named pipe
+    return val;
+  }
+
+  if (port >= 0) {
+    // port number
+    return port;
+  }
+
+  return false;
+}
+
+/**
+ * Event listener for HTTP server "error" event.
+ */
+
+function onError(error) {
+  if (error.syscall !== 'listen') {
+    throw error;
+  }
+
+  var bind = typeof port === 'string'
+    ? 'Pipe ' + port
+    : 'Port ' + port;
+
+  // handle specific listen errors with friendly messages
+  switch (error.code) {
+    case 'EACCES':
+      console.error(bind + ' requires elevated privileges');
+      process.exit(1);
+      break;
+    case 'EADDRINUSE':
+      console.error(bind + ' is already in use');
+      process.exit(1);
+      break;
+    default:
+      throw error;
+  }
+}
+
+/**
+ * Event listener for HTTP server "listening" event.
+ */
+
+function onListening() {
+  var addr = server.address();
+  var bind = typeof addr === 'string'
+    ? 'pipe ' + addr
+    : 'port ' + addr.port;
+  debug('Listening on ' + bind);
+}

--- a/examples/hystrix/package.json
+++ b/examples/hystrix/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "hystrix-example",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "start": "node ./bin/www"
+  },
+  "dependencies": {
+    "body-parser": "~1.16.0",
+    "debug": "~2.6.0",
+    "express": "~4.14.1"
+  }
+}

--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -2,6 +2,7 @@
 
 const EventEmitter = require('events');
 const Status = require('./status');
+const HystrixStats = require('./hystrix-stats');
 
 const STATE = Symbol('state');
 const OPEN = Symbol('open');
@@ -12,6 +13,7 @@ const FALLBACK_FUNCTION = Symbol('fallback');
 const STATUS = Symbol('status');
 const NAME = Symbol('name');
 const GROUP = Symbol('group');
+const HYSTRIX_STATS = Symbol('hystrix-stats');
 const CACHE = new WeakMap();
 
 /**
@@ -95,6 +97,9 @@ class CircuitBreaker extends EventEmitter {
     if (this.options.cache) {
       CACHE.set(this, undefined);
     }
+
+    // Register this instance of the circuit breaker with the hystrix stats listener
+    this[HYSTRIX_STATS] = new HystrixStats(this);
   }
 
   /**
@@ -179,6 +184,12 @@ class CircuitBreaker extends EventEmitter {
     return this[STATUS].stats;
   }
 
+  /**
+    A convenience function that returns the hystrixStats
+  */
+  get hystrixStats () {
+    return this[HYSTRIX_STATS];
+  }
   /**
    * Provide a fallback function for this {@link CircuitBreaker}. This
    * function will be executed when the circuit is `fire`d and fails.

--- a/lib/hystrix-formatter.js
+++ b/lib/hystrix-formatter.js
@@ -1,0 +1,69 @@
+'use strict';
+
+// A function to map our stats data to the hystrix format
+// returns JSON
+function hystrixFormatter (stats) {
+  const json = {};
+  json.type = 'HystrixCommand';
+  json.name = stats.name;
+  json.group = stats.group;
+  json.currentTime = new Date();
+  json.isCircuitBreakerOpen = !stats.closed;
+  json.errorPercentage = stats.fires === 0 ? 0 : (stats.failures / stats.fires) * 100;
+  json.errorCount = stats.failures;
+  json.requestCount = stats.fires;
+  json.rollingCountBadRequests = stats.failures;
+  json.rollingCountCollapsedRequests = 0;
+  json.rollingCountEmit = stats.fires;
+  json.rollingCountExceptionsThrown = 0;
+  json.rollingCountFailure = stats.failures;
+  json.rollingCountFallbackEmit = stats.fallbacks;
+  json.rollingCountFallbackFailure = 0;
+  json.rollingCountFallbackMissing = 0;
+  json.rollingCountFallbackRejection = 0;
+  json.rollingCountFallbackSuccess = 0;
+  json.rollingCountResponsesFromCache = stats.cacheHits;
+  json.rollingCountSemaphoreRejected = stats.rejects;
+  json.rollingCountShortCircuited = stats.rejects;
+  json.rollingCountSuccess = stats.successes;
+  json.rollingCountThreadPoolRejected = 0;
+  json.rollingCountTimeout = stats.timeouts;
+  json.currentConcurrentExecutionCount = 0;
+  json.rollingMaxConcurrentExecutionCount = 0;
+  // TODO: caluclate these latency values
+  json.latencyExecute_mean = 0;
+  json.latencyExecute = {
+    '0': 0,
+    '25': 0,
+    '50': 0,
+    '75': 0,
+    '90': 0,
+    '95': 0,
+    '99': 0,
+    '99.5': 0,
+    '100': 0
+  };
+  json.latencyTotal_mean = 0;
+  json.latencyTotal = { '0': 0, '25': 0, '50': 0, '75': 0, '90': 0, '95': 0, '99': 0, '99.5': 0, '100': 0 };
+  json.propertyValue_circuitBreakerRequestVolumeThreshold = 5;
+  json.propertyValue_circuitBreakerSleepWindowInMilliseconds = stats.options.resetTimeout;
+  json.propertyValue_circuitBreakerErrorThresholdPercentage = stats.options.errorThresholdPercentage;
+  json.propertyValue_circuitBreakerForceOpen = false;
+  json.propertyValue_circuitBreakerForceClosed = false;
+  json.propertyValue_circuitBreakerEnabled = true; // Whether circuit breaker should be enabled.
+  json.propertyValue_executionIsolationStrategy = 'THREAD';
+  json.propertyValue_executionIsolationThreadTimeoutInMilliseconds = 300;
+  json.propertyValue_executionTimeoutInMilliseconds = stats.options.timeout;
+  json.propertyValue_executionIsolationThreadInterruptOnTimeout = true;
+  json.propertyValue_executionIsolationThreadPoolKeyOverride = null;
+  json.propertyValue_executionIsolationSemaphoreMaxConcurrentRequests = 10;
+  json.propertyValue_fallbackIsolationSemaphoreMaxConcurrentRequests = 10;
+  json.propertyValue_metricsRollingStatisticalWindowInMilliseconds = 10000;
+  json.propertyValue_requestCacheEnabled = stats.options.cache || false;
+  json.propertyValue_requestLogEnabled = true;
+  json.reportingHosts = 1;
+
+  return json;
+}
+
+module.exports = exports = hystrixFormatter;

--- a/lib/hystrix-stats.js
+++ b/lib/hystrix-stats.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const stream = require('stream');
+const hystrixFormatter = require('./hystrix-formatter');
+
+/**
+ * @class
+ * <p>
+ * Stream Hystrix Metrics for a given {@link CircuitBreaker}.
+ * A HystrixStats instance is created for every {@link CircuitBreaker}
+ * and does not typically need to be created by a user.
+ * </p>
+ * <p>
+ * A HystrixStats instance will listen for all events on the {@link CircuitBreaker.status.snapshot}
+ * and format the data to the proper Hystrix format.  Making it easy to construct an Event Stream for a client
+ * </p>
+ *
+ * @example
+ * const circuit = circuitBreaker(fs.readFile, {});
+ *
+ * circuit.hystrixStats.getHystrixStream().pipe(response);
+ * @see CircuitBreaker#hystrixStats
+ */
+class HystrixStats {
+  constructor (circuit) {
+    this._circuit = circuit;
+
+    // Listen for the stats's snapshot event
+    this._circuit.status.on('snapshot', this._hystrixSnapshotListener.bind(this));
+
+    this._readableStream = new stream.Readable({
+      objectMode: true
+    });
+
+    // Need a _read() function to satisfy the protocol
+    this._readableStream._read = () => {};
+    this._readableStream.resume();
+
+    this._hystrixStream = new stream.Transform({
+      objectMode: true
+    });
+
+    // Need a _transform() function to satisfy the protocol
+    this._hystrixStream._transform = this._hystrixTransformer;
+    this._hystrixStream.resume();
+
+    this._readableStream.pipe(this._hystrixStream);
+  }
+
+  // The stats coming in should be already "Reduced"
+  _hystrixTransformer (stats, encoding, cb) {
+    const formattedStats = hystrixFormatter(stats);
+
+    // Need to take the stats and map them to the hystrix format
+    return cb(null, `data: ${JSON.stringify(formattedStats)}\n\n`);
+  }
+
+  /**
+    A convenience function that returns the hystrxStream
+  */
+  getHystrixStream () {
+    return this._hystrixStream;
+  }
+
+  // This will take the stats data from the listener and push it on the stream to be transformed
+  _hystrixSnapshotListener (stats) {
+    const circuit = this._circuit;
+    this._readableStream.push(Object.assign({}, {name: circuit.name, closed: circuit.closed, group: circuit.group, options: circuit.options}, stats));
+  }
+}
+
+module.exports = exports = HystrixStats;

--- a/test/test.js
+++ b/test/test.js
@@ -25,6 +25,7 @@ test('api', (t) => {
   t.ok(breaker.closed, 'CircuitBreaker.closed');
   t.ok(breaker.status, 'CircuitBreaker.status');
   t.ok(breaker.options, 'CircuitBreaker.options');
+  t.ok(breaker.hystrixStats, 'CircuitBreaker.hystrixStats');
   t.equals(breaker.action, passFail, 'CircuitBreaker.action');
   t.end();
 });


### PR DESCRIPTION
DO NOT MERGE - this is a WIP for #39 

I've added a Class, `HystrixStats`, which produces a `stream` of the hystrix metrics.

A circuit breaker will `register` with this class during the creation of a circuit breaker, https://github.com/lholmquist/opossum/blob/status-stream-data/lib/circuit.js#L101 so for every snapshot event emitted, the stats stream is updated.

I'm storing the instance of the circuit that is passed in, in a WeakMap so the hystrix event stream can get a handle on it to give me the circuits name, group, etc..


