### PR TITLE
feat: remove fidelity promises.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,13 +2,11 @@
   'use strict';
 
   const CircuitBreaker = require('./lib/circuit');
-  const Fidelity = require('fidelity');
 
   const defaults = {
     timeout: 10000, // 10 seconds
     errorThresholdPercentage: 50,
-    resetTimeout: 30000, // 30 seconds
-    Promise: Fidelity
+    resetTimeout: 30000 // 30 seconds
   };
 
   /**
@@ -25,9 +23,6 @@
    * opening. Default 10.
    * @param options.resetTimeout The time in milliseconds to wait before setting
    * the breaker to `halfOpen` state, and trying the action again.
-   * @param options.Promise {Promise} Opossum uses Fidelity promises, but works
-   * fine with any Promise that follows the spec. You can specify your favored
-   * implementation by providing the constructor as an option.
    * @return a {@link CircuitBreaker} instance
    */
   function circuitBreaker (action, options) {

--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -46,7 +46,6 @@ class CircuitBreaker extends EventEmitter {
     this.options = options;
     this.options.rollingCountTimeout = options.rollingCountTimeout || 10000;
     this.options.rollingCountBuckets = options.rollingCountBuckets || 10;
-    this.Promise = options.Promise;
 
     this[STATUS] = new Status(this.options);
     this[STATE] = CLOSED;
@@ -56,7 +55,7 @@ class CircuitBreaker extends EventEmitter {
     this[GROUP] = options.group || this[NAME];
 
     if (typeof action !== 'function') {
-      this.action = _ => this.Promise.resolve(action);
+      this.action = _ => Promise.resolve(action);
     } else this.action = action;
 
     if (options.maxFailures) console.error('options.maxFailures is deprecated. Please use options.errorThresholdPercentage');
@@ -266,7 +265,7 @@ class CircuitBreaker extends EventEmitter {
 
     let timeout;
     let timeoutError = false;
-    return new this.Promise((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       timeout = setTimeout(
         () => {
           timeoutError = true;
@@ -276,14 +275,14 @@ class CircuitBreaker extends EventEmitter {
            * @event CircuitBreaker#timeout
            */
           this.emit('timeout', error);
-          resolve(fallback(this, error, args) || fail(this, error, args));
+          resolve(handleError(error, this, timeout, args, resolve, reject));
         }, this.options.timeout);
 
       try {
         const result = this.action.apply(this.action, args);
         const promise = (typeof result.then === 'function')
           ? result
-          : this.Promise.resolve(result);
+          : Promise.resolve(result);
 
         promise
           .then((result) => {
@@ -326,7 +325,7 @@ function handleError (error, circuit, timeout, args, resolve, reject) {
 
 function fallback (circuit, err, args) {
   if (circuit[FALLBACK_FUNCTION]) {
-    return new circuit.Promise((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       const result = circuit[FALLBACK_FUNCTION].apply(circuit[FALLBACK_FUNCTION], args);
       /**
        * Emitted when the circuit breaker executes a fallback function
@@ -352,8 +351,6 @@ function fail (circuit, err, args) {
     circuit.options.maxFailures >= stats.failures) {
     circuit.open();
   }
-
-  return circuit.Promise.reject.apply(null, [err]);
 }
 
 // http://stackoverflow.com/a/2117523

--- a/lib/promisify.js
+++ b/lib/promisify.js
@@ -1,10 +1,8 @@
 'use strict';
 
-const Fidelity = require('fidelity');
-
 module.exports = exports = function promisify (func) {
   return function promisifiedFunction () {
-    return new Fidelity((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       const cb = (err, result) => {
         if (err) reject(err);
         resolve(result);

--- a/package.json
+++ b/package.json
@@ -74,6 +74,5 @@
     "fail-fast"
   ],
   "dependencies": {
-    "fidelity": "~4.2.0"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -2,7 +2,6 @@
 
 const browser = require('./browser/browser-tap');
 const test = require('tape');
-const Fidelity = require('fidelity');
 const cb = require('../');
 
 browser.enable();
@@ -118,8 +117,12 @@ test('Fails when the circuit function fails', (t) => {
   const breaker = cb(passFail);
 
   breaker.fire(-1)
-    .then(t.fail)
-    .catch((e) => t.equals(e, 'Error: -1 is < 0', 'expected error caught'))
+    .then(() => {
+      return t.fail;
+    })
+    .catch((e) => {
+      t.equals(e, 'Error: -1 is < 0', 'expected error caught');
+    })
     .then(t.end);
 });
 
@@ -212,7 +215,7 @@ test('Breaker resets after a configurable amount of time', (t) => {
     });
 });
 
-test.skip('Breaker status reflects open state', (t) => {
+test('Breaker status reflects open state', (t) => {
   t.plan(1);
   const breaker = cb(passFail, {errorThresholdPercentage: 0, resetTimeout: 100});
   breaker.fire(-1)
@@ -328,7 +331,7 @@ test('CircuitBreaker status', (t) => {
   const breaker = cb(passFail, { errorThresholdPercentage: 1 });
   const deepEqual = (t, expected) => (actual) => t.deepEqual(actual, expected, 'expected status values');
 
-  Fidelity.all([
+  Promise.all([
     breaker.fire(10).then(deepEqual(t, 10)),
     breaker.fire(20).then(deepEqual(t, 20)),
     breaker.fire(30).then(deepEqual(t, 30))
@@ -366,7 +369,7 @@ test('CircuitBreaker rolling counts', (t) => {
   const opts = { rollingCountTimeout: 200, rollingCountBuckets: 2 };
   const breaker = cb(passFail, opts);
   const deepEqual = (t, expected) => (actual) => t.deepEqual(actual, expected, 'expected status values');
-  Fidelity.all([
+  Promise.all([
     breaker.fire(10).then(deepEqual(t, 10)),
     breaker.fire(20).then(deepEqual(t, 20)),
     breaker.fire(30).then(deepEqual(t, 30))
@@ -642,8 +645,10 @@ test('options.maxFailures should be deprecated', (t) => {
  * Returns a promise that resolves if the parameter
  * 'x' evaluates to >= 0. Otherwise the returned promise fails.
  */
+
+ /* eslint prefer-promise-reject-errors: "off" */
 function passFail (x) {
-  return new Fidelity((resolve, reject) => {
+  return new Promise((resolve, reject) => {
     setTimeout(() => {
       (x > 0) ? resolve(x) : reject(`Error: ${x} is < 0`);
     }, 100);
@@ -655,7 +660,7 @@ function passFail (x) {
  * after 1 second.
  */
 function slowFunction () {
-  return new Fidelity((resolve, reject) => {
+  return new Promise((resolve, reject) => {
     const timer = setTimeout(() => {
       resolve('done');
     }, 10000);


### PR DESCRIPTION
connects to #51


There was one part were i needed to do a little refactoring to get the tests to pass,  which was how we handled errors in the event of a timeout.   https://github.com/bucharest-gold/opossum/compare/master...lholmquist:51-remove-fidelty?expand=1#diff-dbc2c6ba82726efeb035efaaac7c38acR278 and https://github.com/bucharest-gold/opossum/compare/master...lholmquist:51-remove-fidelty?expand=1#diff-dbc2c6ba82726efeb035efaaac7c38acL356


I also removed the option to specify a different Promise library, not sure if that was part of this though