### PR TITLE
feat: add ETIMEDOUT error code for timeout error

### DIFF
--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -280,6 +280,7 @@ class CircuitBreaker extends EventEmitter {
         () => {
           timeoutError = true;
           const error = new Error(`Timed out after ${this.options.timeout}ms`);
+          error.code = 'ETIMEDOUT';
           /**
            * Emitted when the circuit breaker action takes longer than `options.timeout`
            * @event CircuitBreaker#timeout

--- a/test/test.js
+++ b/test/test.js
@@ -127,13 +127,17 @@ test('Fails when the circuit function fails', (t) => {
 });
 
 test('Fails when the circuit function times out', (t) => {
-  t.plan(1);
+  t.plan(2);
   const expected = 'Timed out after 10ms';
+  const expectedCode = 'ETIMEDOUT';
   const breaker = cb(slowFunction, { timeout: 10 });
 
   breaker.fire()
     .then(t.fail)
-    .catch((e) => t.equals(e.message, expected, 'timeout message received'))
+    .catch((e) => {
+      t.equals(e.message, expected, 'timeout message received');
+      t.equals(e.code, expectedCode, 'ETIMEDOUT');
+    })
     .then(t.end);
 });
 


### PR DESCRIPTION
Added an error code `ETIMEDOUT` to easily identify timeout error at caller site. Previously, we need to do checking with e.g. `indexOf('Timed out') >= 0`.

This is useful when we need to abort or cancel the underlying process. The following contrived example tries to depict the usefulness of having `ETIMEDOUT` as `error.code` for when breaker timed out.

```js
const circuitBreaker = require('./');

let handle;

function asyncTimeout () {
  return new Promise((resolve) => {
    handle = setTimeout(() => {
      console.log('timeout!');
      resolve();
    }, 1000);
  });
}

const breaker = circuitBreaker(asyncTimeout, { timeout: 500 });
breaker.fire()
  .then(console.log)
  .catch((err) => {
    // this is very naive but, imagine we have access to abort function for the underlying process
    // without this, the asyncTimeout will be fired.
    if (err.code === 'ETIMEDOUT') { // rather than e.message.indexOf('Timed out') === 0
      clearTimeout(handle);
    }
    console.error(err);
  });
```