### PR TITLE
Add health check function to a circuit breaker

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Here are the events you can listen for.
 * `halfOpen` - emitted when the breaker state changes to `halfOpen`
 * `fallback` - emitted when the breaker has a fallback function and executes it
 * `semaphore-locked` - emitted when the breaker is at capacity and cannot execute the request
+* `health-check-failed` - emitted when a user-supplied health check function returns a rejected promise
 
 Handling events gives a greater level of control over your application behavior.
 

--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -348,6 +348,49 @@ class CircuitBreaker extends EventEmitter {
   clearCache () {
     CACHE.set(this, undefined);
   }
+
+  /**
+   * Provide a health check function to be called periodically. The function should
+   * return a Promise. If the promise is rejected, the circuit will open. This is
+   * in addition to the existing circuit behavior as defined by `options.errorThresholdPercentage`
+   * in the constructor. For example, if the health check function provided here
+   * always returns a resolved promise, the circuit can still trip and open if
+   * there are failures exceeding the configured threshold. The health check function
+   * is excecuted within the circuit breaker's execution context, so `this` within
+   * the function is the circuit breaker itself.
+   *
+   * @param func {Function} a health check function which returns a promise.
+   * @param [interval] {Number} the amount of time between calls to the health
+   * check function. Default: 5000 (5 seconds)
+   *
+   * @returns {Promise}
+   *
+   * @fires CircuitBreaker#health-check-failed
+   * @throws TypeError if `interval` is supplied but not a number
+   */
+  healthCheck (func, interval) {
+    interval = interval || 5000;
+    if (isNaN(interval)) throw new TypeError('Health check interval must be a function');
+
+    const check = _ => {
+      func.apply(this).catch(e => {
+        /**
+         * Emitted with the user-supplied health check function
+         * returns a rejected promise.
+         * @event CircuitBreaker#health-check-failed
+         */
+        this.emit('health-check-failed', e);
+        this.open();
+      });
+    };
+
+    const timer = setInterval(check, interval);
+    if (typeof timer.unref === 'function') {
+      timer.unref();
+    }
+
+    check();
+  }
 }
 
 function handleError (error, circuit, timeout, args, latency, resolve, reject) {

--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -370,7 +370,8 @@ class CircuitBreaker extends EventEmitter {
    */
   healthCheck (func, interval) {
     interval = interval || 5000;
-    if (isNaN(interval)) throw new TypeError('Health check interval must be a function');
+    if (typeof func !== 'function') throw new TypeError('Health check function must be a function');
+    if (isNaN(interval)) throw new TypeError('Health check interval must be a number');
 
     const check = _ => {
       func.apply(this).catch(e => {

--- a/test/common.js
+++ b/test/common.js
@@ -1,0 +1,55 @@
+'use strict';
+
+/**
+ * Returns a promise that resolves if the parameter
+ * 'x' evaluates to >= 0. Otherwise the returned promise fails.
+ */
+
+ /* eslint prefer-promise-reject-errors: "off" */
+function passFail (x) {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      (x > 0) ? resolve(x) : reject(`Error: ${x} is < 0`);
+    }, 100);
+  });
+}
+
+/**
+ * A function returning a promise that resolves
+ * after 1 second.
+ */
+function slowFunction () {
+  return timedFunction(10000);
+}
+
+function timedFunction (ms) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      resolve('done');
+    }, ms);
+    if (typeof timer.unref === 'function') {
+      timer.unref();
+    }
+  });
+}
+
+function nonPromise () {
+  return 'foo';
+}
+
+function callbackFunction (x, y, callback) {
+  callback(null, x + y);
+}
+
+function failedCallbackFunction () {
+  Array.prototype.slice.call(arguments).pop()('Whoops!');
+}
+
+module.exports = exports = {
+  passFail,
+  slowFunction,
+  timedFunction,
+  callbackFunction,
+  failedCallbackFunction,
+  nonPromise
+};

--- a/test/health-check-test.js
+++ b/test/health-check-test.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const test = require('tape');
+const opossum = require('../');
+const common = require('./common');
+
+test('Circuits accept a health check function', t => {
+  t.plan(1);
+  const circuit = opossum(common.passFail);
+  circuit.healthCheck(healthChecker(_ => {
+    t.ok(true, 'function called');
+    t.end();
+    return Promise.resolve();
+  }));
+});
+
+test('health-check-failed is emitted on failure', t => {
+  t.plan(1);
+  const circuit = opossum(common.passFail);
+  circuit.on('health-check-failed', e => {
+    t.equals(e.message, 'Too many tacos', 'health-check-failed emitted');
+    t.end();
+  });
+  circuit.healthCheck(healthChecker(_ => {
+    return Promise.reject(new Error('Too many tacos'));
+  }));
+});
+
+test('circuit opens on health check failure', t => {
+  t.plan(1);
+  const circuit = opossum(common.passFail);
+  circuit.on('open', e => {
+    t.ok(circuit.opened, 'circuit opened');
+    t.end();
+  });
+  circuit.healthCheck(healthChecker(_ => {
+    return Promise.reject(new Error('Too many tacos'));
+  }));
+});
+
+test('Health check function executes in the circuit breaker context', t => {
+  t.plan(1);
+  let called = false;
+  const circuit = opossum(common.passFail);
+  circuit.healthCheck(function healthCheck () {
+    if (!called) {
+      t.equal(this, circuit, 'health check executes in circuit context');
+      t.end();
+    }
+    called = true;
+    return Promise.resolve();
+  });
+});
+
+const healthChecker = func => _ => {
+  let called = false;
+  if (!called) return func();
+  called = true;
+  return Promise.resolve();
+};

--- a/test/health-check-test.js
+++ b/test/health-check-test.js
@@ -11,7 +11,7 @@ test('Circuits accept a health check function', t => {
     t.ok(true, 'function called');
     t.end();
     return Promise.resolve();
-  }));
+  }), 10000);
 });
 
 test('health-check-failed is emitted on failure', t => {
@@ -23,7 +23,7 @@ test('health-check-failed is emitted on failure', t => {
   });
   circuit.healthCheck(healthChecker(_ => {
     return Promise.reject(new Error('Too many tacos'));
-  }));
+  }), 10000);
 });
 
 test('circuit opens on health check failure', t => {
@@ -35,7 +35,7 @@ test('circuit opens on health check failure', t => {
   });
   circuit.healthCheck(healthChecker(_ => {
     return Promise.reject(new Error('Too many tacos'));
-  }));
+  }), 10000);
 });
 
 test('Health check function executes in the circuit breaker context', t => {
@@ -49,7 +49,7 @@ test('Health check function executes in the circuit breaker context', t => {
     }
     called = true;
     return Promise.resolve();
-  });
+  }, 10000);
 });
 
 const healthChecker = func => _ => {

--- a/test/health-check-test.js
+++ b/test/health-check-test.js
@@ -52,6 +52,32 @@ test('Health check function executes in the circuit breaker context', t => {
   }, 10000);
 });
 
+test('Health check function throws a TypeError if the interval duration is not a number', t => {
+  t.plan(2);
+  const circuit = opossum(common.passFail);
+  try {
+    circuit.healthCheck(_ => {}, 'Biscuits and gravy');
+    t.fail('Circuit breaker did not throw TypeError');
+  } catch (e) {
+    t.equals(e.constructor, TypeError, 'throws TypeError');
+    t.equals(e.message, 'Health check interval must be a number', 'include correct message');
+    t.end();
+  }
+});
+
+test('Health check function throws a TypeError if the function parameter is not a function', t => {
+  t.plan(2);
+  const circuit = opossum(common.passFail);
+  try {
+    circuit.healthCheck('Biscuits and gravy');
+    t.fail('Circuit breaker did not throw TypeError');
+  } catch (e) {
+    t.equals(e.constructor, TypeError, 'throws TypeError');
+    t.equals(e.message, 'Health check function must be a function', 'include correct message');
+    t.end();
+  }
+});
+
 const healthChecker = func => _ => {
   let called = false;
   if (!called) return func();

--- a/test/test.js
+++ b/test/test.js
@@ -732,47 +732,10 @@ test('CircuitBreaker semaphore rate limiting', (t) => {
   });
 });
 
-/**
- * Returns a promise that resolves if the parameter
- * 'x' evaluates to >= 0. Otherwise the returned promise fails.
- */
-
- /* eslint prefer-promise-reject-errors: "off" */
-function passFail (x) {
-  return new Promise((resolve, reject) => {
-    setTimeout(() => {
-      (x > 0) ? resolve(x) : reject(`Error: ${x} is < 0`);
-    }, 100);
-  });
-}
-
-/**
- * A function returning a promise that resolves
- * after 1 second.
- */
-function slowFunction () {
-  return timedFunction(10000);
-}
-
-function timedFunction (ms) {
-  return new Promise((resolve, reject) => {
-    const timer = setTimeout(() => {
-      resolve('done');
-    }, ms);
-    if (typeof timer.unref === 'function') {
-      timer.unref();
-    }
-  });
-}
-
-function nonPromise () {
-  return 'foo';
-}
-
-function callbackFunction (x, y, callback) {
-  callback(null, x + y);
-}
-
-function failedCallbackFunction () {
-  Array.prototype.slice.call(arguments).pop()('Whoops!');
-}
+const common = require('./common');
+const passFail = common.passFail;
+const slowFunction = common.slowFunction;
+const timedFunction = common.timedFunction;
+const nonPromise = common.nonPromise;
+const callbackFunction = common.callbackFunction;
+const failedCallbackFunction = common.failedCallbackFunction;


### PR DESCRIPTION
## Add `circuit.healthCheck(func[, interval])`

Exposes a way for users to provide their own health check function. The provided function
should return a promise. If the promise is rejected, the circuit will open and the `health-check-failed` event will be emitted.

## Usage
```js
const circuit = opossum(myFunction);
circuit.healthCheck(_ => {
    // check the status of the remote service
    if (remoteServiceDown) {
       return Promise.reject('Cannot connect to remote service');
    }
    return Promise.resolve();
  }, 10000); // check interval - default is 5000

circuit.on('health-check-failed', (err) => {
  // send a text message to the poor sysadmin
  sendErrorText(err);
});
```
