### PR TITLE
Add failure check function to a circuit breaker

### DIFF
--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -11,6 +11,7 @@ const CLOSED = Symbol('closed');
 const HALF_OPEN = Symbol('half-open');
 const PENDING_CLOSE = Symbol('pending-close');
 const FALLBACK_FUNCTION = Symbol('fallback');
+const FAILURE_CHECK_FUNCTION = Symbol('is-failure');
 const STATUS = Symbol('status');
 const NAME = Symbol('name');
 const GROUP = Symbol('group');
@@ -62,6 +63,7 @@ class CircuitBreaker extends EventEmitter {
     this[STATUS] = new Status(this.options);
     this[STATE] = CLOSED;
     this[FALLBACK_FUNCTION] = null;
+    this[FAILURE_CHECK_FUNCTION] = null;
     this[PENDING_CLOSE] = false;
     this[NAME] = options.name || action.name || nextName();
     this[GROUP] = options.group || this[NAME];
@@ -224,6 +226,24 @@ class CircuitBreaker extends EventEmitter {
       };
     }
     this[FALLBACK_FUNCTION] = fb;
+    return this;
+  }
+
+  /**
+   * Provide a failure check function to be called when the action throws/rejects an error.
+   * If this function returns true, then the error counts as a failure. Otherwise, the error
+   * is expected and should count as a success intead. Without calling this function, all
+   * errors are treated as failures that count towards opening circuit breaker.
+   *
+   * @param func {Function} a failure check function which returns a boolean.
+   *
+   * @returns {Boolean}
+   *
+   * @throws TypeError if `func` is supplied but not a function.
+   */
+  failureCheck (func) {
+    if (typeof func !== 'function') throw new TypeError('Failure check function must be a function');
+    this[FAILURE_CHECK_FUNCTION] = func;
     return this;
   }
 
@@ -423,18 +443,27 @@ function fallback (circuit, err, args) {
 }
 
 function fail (circuit, err, args, latency) {
-  /**
-   * Emitted when the circuit breaker action fails
-   * @event CircuitBreaker#failure
-   */
-  circuit.emit('failure', err, latency);
+  if (circuit[FAILURE_CHECK_FUNCTION] &&
+    !(circuit[FAILURE_CHECK_FUNCTION].call(circuit[FAILURE_CHECK_FUNCTION], err))) {
+    /**
+     * This error is not considered a failure
+     * @event CircuitBreaker#success
+     */
+    circuit.emit('success', err, latency);
+  } else {
+    /**
+     * Emitted when the circuit breaker action fails
+     * @event CircuitBreaker#failure
+     */
+    circuit.emit('failure', err, latency);
 
-  // check stats to see if the circuit should be opened
-  const stats = circuit.stats;
-  const errorRate = stats.failures / stats.fires * 100;
-  if (errorRate > circuit.options.errorThresholdPercentage ||
-    circuit.options.maxFailures >= stats.failures) {
-    circuit.open();
+    // check stats to see if the circuit should be opened
+    const stats = circuit.stats;
+    const errorRate = stats.failures / stats.fires * 100;
+    if (errorRate > circuit.options.errorThresholdPercentage ||
+      circuit.options.maxFailures >= stats.failures) {
+      circuit.open();
+    }
   }
 }
 


### PR DESCRIPTION
## Add circuit.failureCheck(func)

Exposes a way to separate which errors should be considered a failure that counts toward tripping the breaker. If the function returns true, then it should count as a failure. I find that I need this feature since I'd like to wrap some http functions with circuit breaker, but only want to trip on certain http status codes.

## Usage

```javascript
const circuit = opossum(myHttpFunction)

circuit.failureCheck(e => {
  // Only consider error with status code >= 500 as failures
  return e.statusCode >= 500;
})

circuit.fire();
```

## To-Do

* [ ] Update README

## Things to Consider

* Currently if the function returns false, I simply emit success with the error as an argument. Anything else that should be done?

Thanks beforehand 🙇 