### PR TITLE
Half-open state does not keep rejecting, and doesn't trigger re-try

### DIFF
--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -270,7 +270,7 @@ class CircuitBreaker extends EventEmitter {
       this.emit('cacheMiss');
     }
 
-    if (this.opened && !this.pendingClose) {
+    if (!this.closed && !this.pendingClose) {
       /**
        * Emitted when the circuit breaker is open and failing fast
        * @event CircuitBreaker#reject
@@ -432,7 +432,8 @@ function fail (circuit, err, args, latency) {
   const stats = circuit.stats;
   const errorRate = stats.failures / stats.fires * 100;
   if (errorRate > circuit.options.errorThresholdPercentage ||
-    circuit.options.maxFailures >= stats.failures) {
+    circuit.options.maxFailures >= stats.failures ||
+    circuit.halfOpen) {
     circuit.open();
   }
 }


### PR DESCRIPTION
Proposed fix for issues reported in https://github.com/bucharest-gold/opossum/issues/119

This fix addresses the fact that once the circuit goes "half-open" it lets all further requests through, not just the first one. And the follow-on issue that failure of the first request let through does not guarantee the circuit gets treated as "open" again.