### PR TITLE
build: conditionally install npm@5 if it's not available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
   - "8"
   - "9"
 before_install:
+  - if [ $(npm --version | cut -d'.' -f1) != "5" ] ; then npm install -g npm@5 ; fi
   - npm install -g greenkeeper-lockfile@1
 before_script:
   - export DISPLAY=:99.0


### PR DESCRIPTION
This is really only a problem on travis-ci for Node 6 builds.