### PR TITLE
changed currentTime to number as specified in the docs

### DIFF
--- a/lib/hystrix-formatter.js
+++ b/lib/hystrix-formatter.js
@@ -11,7 +11,7 @@ function hystrixFormatter (stats) {
     type: 'HystrixCommand',
     name: stats.name,
     group: stats.group,
-    currentTime: new Date(),
+    currentTime: Date.now(),
     isCircuitBreakerOpen: !stats.closed,
     errorPercentage:
       stats.fires === 0 ? 0 : (stats.failures / stats.fires) * 100,


### PR DESCRIPTION
The hystrix stream data is not compatible with turbine, the specs says that currentTime is a ```Number``` but the provided type is of date string in ```hystrix-formatter.js```. see https://github.com/Netflix/Hystrix/wiki/Metrics-and-Monitoring#metrics-publisher

fix #225 