### PR TITLE
Changing the circuit breaker default capacity from 10 to MAX_SAFE_INT…

### DIFF
--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -74,7 +74,7 @@ class CircuitBreaker extends EventEmitter {
     this.options.rollingCountBuckets = options.rollingCountBuckets || 10;
     this.options.rollingPercentilesEnabled =
       options.rollingPercentilesEnabled !== false;
-    this.options.capacity = Number.isInteger(options.capacity) ? options.capacity : 10;
+    this.options.capacity = Number.isInteger(options.capacity) ? options.capacity : Number.MAX_SAFE_INTEGER;
 
     this.semaphore = new Semaphore(this.options.capacity);
 

--- a/test/test.js
+++ b/test/test.js
@@ -786,6 +786,12 @@ test('CircuitBreaker semaphore rate limiting', t => {
   });
 });
 
+test('CircuitBreaker default capacity', t => {
+  const breaker = circuit(passFail);
+  t.equals(breaker.options.capacity, Number.MAX_SAFE_INTEGER);
+  t.end();
+});
+
 const noop = _ => {};
 const common = require('./common');
 const identity = common.identity;


### PR DESCRIPTION
This pull request resolves the issue https://github.com/bucharest-gold/opossum/issues/230 by changing the default circuit breaker capacity from 10 to MAX_SAFE_INTEGER.